### PR TITLE
fix: resolve jest-fetch-mock Request type errors in tests

### DIFF
--- a/src/aws/api.test.ts
+++ b/src/aws/api.test.ts
@@ -1,5 +1,4 @@
 import fetchMock from 'jest-fetch-mock';
-import { Request } from 'node-fetch';
 import { either as E } from 'fp-ts';
 import { pollForNextEvent, registerExtension } from '~/aws/api';
 
@@ -14,7 +13,7 @@ describe('test AWS Extension registration', () => {
 
   test('registration succeeds with 200', async () => {
     fetchMock.mockIf(
-      (request: Request) =>
+      (request) =>
         request.url === `${baseUrl}/extension/register` &&
         request.headers.get('Lambda-Extension-Name') === EXTENSION_NAME,
       JSON.stringify({ message: 'ok' }),
@@ -37,7 +36,7 @@ describe('test AWS Extension registration', () => {
 
   test('registration should throw if no extension name header is returned', async () => {
     fetchMock.mockIf(
-      (request: Request) =>
+      (request) =>
         request.url === `${baseUrl}/extension/register` &&
         request.headers.get('Lambda-Extension-Name') === EXTENSION_NAME,
       JSON.stringify({ message: 'ok' }),
@@ -61,7 +60,7 @@ describe('test AWS extension next event', () => {
 
   test('pollForNextEvent should succeed with valid response', async () => {
     fetchMock.mockIf(
-      (request: Request) =>
+      (request) =>
         request.url === `${baseUrl}/extension/event/next` &&
         request.headers.get('Lambda-Extension-Identifier') === extensionId,
       JSON.stringify({
@@ -82,7 +81,7 @@ describe('test AWS extension next event', () => {
 
   test('pollForNextEvent should fail with error response', async () => {
     fetchMock.mockIf(
-      (request: Request) =>
+      (request) =>
         request.url === `${baseUrl}/extension/event/next` &&
         request.headers.get('Lambda-Extension-Identifier') === extensionId,
       JSON.stringify({}),

--- a/src/aws/subscribe.test.ts
+++ b/src/aws/subscribe.test.ts
@@ -1,6 +1,5 @@
 import { subscribeTelemetry, SubscriptionBody } from '~/aws/subscribe';
 import fetchMock from 'jest-fetch-mock';
-import { Request } from 'node-fetch';
 import { either as E } from 'fp-ts';
 
 describe('test AWS Extension Telemetry', () => {
@@ -13,7 +12,7 @@ describe('test AWS Extension Telemetry', () => {
 
   test('telemetry subscription succeeds with 200', async () => {
     fetchMock.mockIf(
-      (request: Request) =>
+      (request) =>
         request.url === `${baseUrl}/telemetry` && request.headers.get('Lambda-Extension-Identifier') === extensionId,
       JSON.stringify({ message: 'ok' }),
       { status: 200 },
@@ -38,7 +37,7 @@ describe('test AWS Extension Telemetry', () => {
 
   test('telemetry subscription should throw on non-200', async () => {
     fetchMock.mockIf(
-      (request: Request) =>
+      (request) =>
         request.url === `${baseUrl}/telemetry` && request.headers.get('Lambda-Extension-Identifier') === extensionId,
       JSON.stringify({ message: 'ok' }),
       { status: 202 },

--- a/src/forwarders/logtail.test.ts
+++ b/src/forwarders/logtail.test.ts
@@ -1,5 +1,4 @@
 import fetchMock from 'jest-fetch-mock';
-import { Request } from 'node-fetch';
 import { either as E } from 'fp-ts';
 import { logtailLogForwarder, parseMessageWithPowertoolsLogFormat } from '~/forwarders/logtail';
 import { FunctionLogEvent } from '~/aws/events';
@@ -19,7 +18,7 @@ describe('test logtail log forwarding', () => {
   };
 
   test('forwarder should empty logs queue on successful POST', async () => {
-    fetchMock.mockIf((request: Request) => request.url === ingestionUrl, JSON.stringify({ message: 'ok' }), {
+    fetchMock.mockIf((request) => request.url === ingestionUrl, JSON.stringify({ message: 'ok' }), {
       status: 200,
     });
 
@@ -45,7 +44,7 @@ describe('test logtail log forwarding', () => {
   });
 
   test('forwarder should re-queue logs on failure', async () => {
-    fetchMock.mockIf((request: Request) => request.url === ingestionUrl, JSON.stringify({ message: 'bad' }), {
+    fetchMock.mockIf((request) => request.url === ingestionUrl, JSON.stringify({ message: 'bad' }), {
       status: 500,
     });
 


### PR DESCRIPTION
## Summary

This PR fixes TypeScript type errors in test files caused by a mismatch between the `Request` type from `node-fetch` and the type expected by `jest-fetch-mock`'s `mockIf` predicate.

## Problem

Previously, the tests imported `Request` from `node-fetch` and used it as the type for the predicate in `fetchMock.mockIf`. However, `jest-fetch-mock` expects the global (DOM/Web API) `Request` type, not the one from `node-fetch`. This caused type errors like:

``` 
Argument of type '(request: Request) => boolean' is not assignable to parameter of type 'UrlOrPredicate'.
Type '(request: Request) => boolean' is not assignable to type '(input: Request) => boolean'.
Types of parameters 'request' and 'input' are incompatible.
Type 'Request' is missing the following properties from type 'Request': referrer, size, buffer
```

## Solution

- Removed all imports of `Request` from `node-fetch` in test files.
- Updated all `fetchMock.mockIf` predicates to use the global `Request` type (or let TypeScript infer the type).
- No changes to production code; only test files were updated.

## Files Updated

- `src/aws/api.test.ts`
- `src/aws/subscribe.test.ts`
- `src/forwarders/logtail.test.ts`

## Testing

- Ran `npm run build` and all tests pass successfully.
- No type errors remain.

---

Let me know if you need anything else!